### PR TITLE
Removed duplicate variable declaration

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -7,7 +7,6 @@ var path = require('path');
 var port = process.argv[2] || 8043;
 var insecurePort = process.argv[3] || 4080;
 var fs = require('fs');
-var path = require('path');
 var checkip = require('check-ip-address');
 var server;
 var insecureServer;


### PR DESCRIPTION
The "path" variable declaration and value assignment in serve.js was done twice.
